### PR TITLE
Update connection to use SSL

### DIFF
--- a/api/models/database.js
+++ b/api/models/database.js
@@ -7,6 +7,7 @@ class Database {
   constructor() {
     const config = {
       connectionString: process.env.DATABASE_URL,
+      ssl: true,
     };
     this.client = new Client(config);
     this.client.connect();


### PR DESCRIPTION
The previous connection did not use SSL which is required for `heroku-postgres`
Update connection to include SSL